### PR TITLE
Fix claim logic

### DIFF
--- a/programs/crowdfund/src/lib.rs
+++ b/programs/crowdfund/src/lib.rs
@@ -158,8 +158,16 @@ pub mod crowdfund {
         //basically, only the "owner" of the funds could take advantage by passing in a different ata
 
         //Calculate amount of purchased SPL a user is entitled to
-        let claim_amount = (receipt.amount_deposited * surge.spl_amount) / surge.amount_deposited;
-        let sol_claim_amount = (receipt.amount_deposited * surge.leftover_sol) / surge.amount_deposited;
+        let receipt_amt_deposited_128 = u128::from(receipt.amount_deposited);
+        let surge_spl_amt_128 = u128::from(surge.spl_amount);
+        let surge_total_deposits_128 = u128::from(surge.amount_deposited);
+        let surge_leftover_128 = u128::from(surge.leftover_sol);
+
+        let claim_amount_128 = (receipt_amt_deposited_128 * surge_spl_amt_128) / surge_total_deposits_128;
+        let sol_claim_amount_128 = (receipt_amt_deposited_128 * surge_leftover_128) / surge_total_deposits_128;
+
+        let claim_amount = u64::try_from(claim_amount_128)?;
+        let sol_claim_amount = u64::try_from(sol_claim_amount_128)?;
         //determine entitlement based on claim
         let cpi_accounts = SplTransfer {
             from: surge_escrow_ata.to_account_info().clone(),

--- a/tests/crowdfund.ts
+++ b/tests/crowdfund.ts
@@ -86,7 +86,8 @@ describe("crowdfund", () => {
     //This is stub out for allowing surge to purchase tokens directly
     //It is going to "mintTo" a surge ATA a fixed amount of an SPL
     //which will later be claimed by receipt owner
-    mintProgram = await splToken.createMint(
+    mintProgram = new PublicKey(IMPORTED_ACCOUNTS.OGGY_MINT);
+    /* mintProgram = await splToken.createMint(
       provider.connection,
       signer,
       mintKeyPair.publicKey,
@@ -95,7 +96,7 @@ describe("crowdfund", () => {
       undefined,
       {},
       splToken.TOKEN_PROGRAM_ID
-    )
+    ) */
     //create ATA for surge account
     surgeAta = await splToken.getOrCreateAssociatedTokenAccount(
       provider.connection,
@@ -106,7 +107,7 @@ describe("crowdfund", () => {
     )
 
     console.log("SURGE ATA IS " + surgeAta.address)
-    const mint = await splToken.mintTo(
+    /* const mint = await splToken.mintTo(
       provider.connection,
       signer,
       mintProgram,
@@ -116,7 +117,7 @@ describe("crowdfund", () => {
       [],
       undefined,
       splToken.TOKEN_PROGRAM_ID
-    )
+    ) */
     const populatedAta = await splToken.getAccount(
       provider.connection,
       surgeAta.address,


### PR DESCRIPTION
- convert u64 to u128
- store `mint` on Surge receipt for claim
- clean up the try_borrow_mut_lamports logic for the more readable solana program system transfer
- adjust test file in accordance